### PR TITLE
added modifier class, lists, and creation logic

### DIFF
--- a/components/equipment.py
+++ b/components/equipment.py
@@ -45,7 +45,7 @@ class Equipment:
     def toggle_equip(self, equippable_entity):
         results = []
 
-        slot = equippable_entity.equippable.slot     
+        slot = equippable_entity.equippable.slot
 
         # There is 100% a way to combine each of these to reduce repetition
         if slot == EquipmentSlots.MAIN_HAND:

--- a/components/equippable.py
+++ b/components/equippable.py
@@ -1,6 +1,36 @@
+from random_utils import from_dungeon_level, random_choice_from_dict
+from components.modifier import equippable_material, equippable_enchantment
+from equipment_slots import EquipmentSlotGroups
+
 class Equippable:
     def __init__(self, slot, power_bonus=0, defense_bonus=0, max_hp_bonus=0):
         self.slot = slot
         self.power_bonus = power_bonus
         self.defense_bonus = defense_bonus
         self.max_hp_bonus = max_hp_bonus
+        # Modifiers are currently added directly instead of being their own attributes but it might actually be nice to know what kind of modifier an item is
+
+    def generate_material(self, dungeon_level):
+        "Generates a random material for the given item based on dungeon level. The modifier will potentially apply a bonus and change the name of the item. Bonus will usually be defensive for armor and offensive for weapons"
+        modifierChances = {key: from_dungeon_level(value.chance, dungeon_level) for key, value in equippable_material.items() if self.slot in value.slot_restrictions}
+        modifier_name = random_choice_from_dict(modifierChances)
+        modifier = equippable_material.get(modifier_name)
+        if modifier.bonus_dic:
+            for _, value in modifier.bonus_dic.items():
+                # Set power if weapon, defense if armor
+                if self.slot in EquipmentSlotGroups.WEAPONS: setattr(self, 'power_bonus', getattr(self, 'power_bonus') + value)
+                else: setattr(self, 'defense_bonus', getattr(self, 'defense_bonus') + value)
+                return modifier_name + ' '
+        return ''
+
+    def generate_enchantment(self, dungeon_level):
+        "Generates a random enchantment for the given item based on dungeon level. The modifier will potentially apply a bonus and change the name of the item"
+        modifierChances = {key: from_dungeon_level(value.chance, dungeon_level) for key, value in equippable_enchantment.items() if self.slot in value.slot_restrictions}
+        modifier_name = random_choice_from_dict(modifierChances)
+        modifier = equippable_enchantment.get(modifier_name)
+        if modifier.bonus_dic:
+            for key, value in modifier.bonus_dic.items():
+                # Bonus type is whatever is written in modifier
+                setattr(self, key, getattr(self, key) + value)
+                return ' of ' + modifier_name
+        return ''

--- a/components/modifier.py
+++ b/components/modifier.py
@@ -1,0 +1,20 @@
+from random_utils import from_dungeon_level, random_choice_from_dict
+from equipment_slots import EquipmentSlotGroups
+
+class Modifier:
+    def __init__(self, chance, bonus_dic=None, slot_restrictions=EquipmentSlotGroups.ALL):
+        self.chance = chance
+        self.bonus_dic = bonus_dic
+        self.slot_restrictions = slot_restrictions
+
+equippable_material = {
+  'Wooden': Modifier([30], {'bonus': 0}), # The key here really does not matter since bonus type is determined by slot
+  'Iron': Modifier([[15, 1], [50, 3]], {'bonus': 1}),
+  'Steel': Modifier([[5, 1], [60, 5]], {'bonus': 2})
+}
+
+equippable_enchantment = {
+  '': Modifier([70], {}), # No Enchantment
+  'Flames': Modifier([10], EquipmentSlotGroups.WEAPONS, {'power_bonus': 2}),
+  'Strength': Modifier([10], {'power_bonus': 1, 'defense_bonus': 1})
+}

--- a/equipment_slots.py
+++ b/equipment_slots.py
@@ -9,3 +9,8 @@ class EquipmentSlots(Enum):
     HANDS = auto()
     LEGS = auto()
     FEET = auto()
+
+class EquipmentSlotGroups():
+    WEAPONS = [EquipmentSlots.MAIN_HAND]
+    ARMOR = [EquipmentSlots.HEAD, EquipmentSlots.CHEST, EquipmentSlots.HANDS, EquipmentSlots.LEGS, EquipmentSlots.FEET, EquipmentSlots.OFF_HAND]
+    ALL = [EquipmentSlots.MAIN_HAND, EquipmentSlots.OFF_HAND, EquipmentSlots.HEAD, EquipmentSlots.CHEST, EquipmentSlots.HANDS, EquipmentSlots.LEGS, EquipmentSlots.FEET]

--- a/items.py
+++ b/items.py
@@ -9,24 +9,23 @@ from components.equippable import Equippable
 from components.fighter import Fighter
 from components.ai import BasicMonster
 
-
-
+# item and monster modifiers are more related to items and monster sthatn each other so put item modifiers here instead of their own class with monster modifier
 items = {
 
   # WEAPONS
 
-  'dagger': Entity([0], 0, 0, "-", libtcod.sky, "Dagger", 
+  'dagger': Entity([[20, 1], [0, 4]], 0, 0, "-", libtcod.sky, "Dagger", 
     equippable=Equippable(EquipmentSlots.MAIN_HAND, power_bonus=1)),
 
-  'sword': Entity([[5,4]], -1, -1, '/', libtcod.sky, 'Sword', 
+  'sword': Entity([[5,1]], -1, -1, '/', libtcod.sky, 'Sword', 
     equippable=Equippable(EquipmentSlots.MAIN_HAND, power_bonus=3)),
 
-  'shield': Entity([[15, 8]], -1, -1, '[', libtcod.darker_orange, 'Shield', 
+  'shield': Entity([[15, 2]], -1, -1, '[', libtcod.darker_orange, 'Shield', 
     equippable=Equippable(EquipmentSlots.OFF_HAND, defense_bonus=1)),
 
   # ARMOR
 
-  'cap':  Entity([100], -1, -1, 'c', libtcod.darker_green, 'Cap', 
+  'cap':  Entity([[20, 1]], -1, -1, 'c', libtcod.darker_green, 'Cap',
     equippable=Equippable(EquipmentSlots.HEAD, defense_bonus=1)),
 
   # USABLES
@@ -34,10 +33,10 @@ items = {
   'healing_potion': Entity([35], -1, -1, '!', libtcod.violet, 'Healing Potion', render_order=RenderOrder.ITEM, 
     usable=Usable(use_function=heal, amount=40)),
 
-  'lightning_scroll': Entity([[25, 4]], -1, -1, '#', libtcod.yellow, 'Lightning Scroll', render_order=RenderOrder.ITEM,
+  'lightning_scroll': Entity([[25, 3]], -1, -1, '#', libtcod.yellow, 'Lightning Scroll', render_order=RenderOrder.ITEM,
     usable=Usable(use_function=cast_lightning, damage=40, maximum_range=7)),
 
-  'fireball_scroll': Entity([[25, 6]], -1, -1, '#', libtcod.light_crimson, 'Fireball Scroll', render_order=RenderOrder.ITEM, 
+  'fireball_scroll': Entity([[25, 4]], -1, -1, '#', libtcod.light_crimson, 'Fireball Scroll', render_order=RenderOrder.ITEM, 
     usable=Usable(use_function=cast_fireball, targeting=True, targeting_message=Message('You ready a fireball. (Left click to cast, right click to cancel.)', libtcod.light_cyan),damage=25,radius=3)),
 
   'confuse_scroll': Entity([[10, 2]], -1, -1, '#', libtcod.light_purple, 'Confuse Scroll', render_order=RenderOrder.ITEM,

--- a/loader_functions/initialize_new_game.py
+++ b/loader_functions/initialize_new_game.py
@@ -25,7 +25,7 @@ from render_functions import RenderOrder
 
 
 def get_constants():
-    window_title = "Gou 0.1 - Tutorial Testing"
+    window_title = "Gou Prototype 1.0v1 0 Alpona"
 
     screen_width = 80
     screen_height = 50

--- a/map_objects/game_map.py
+++ b/map_objects/game_map.py
@@ -106,6 +106,7 @@ class GameMap:
             self.tiles[x][y].block_sight = False
 
     def place_entities(self, room, entities):
+        # TODO This will need to be moved once we add supoort for different types of dungeons
         max_monsters_per_room = from_dungeon_level([[2, 1], [3, 4], [5, 6]], self.dungeon_level)
         max_items_per_room = from_dungeon_level([[1, 1], [2, 4]], self.dungeon_level)
 
@@ -146,6 +147,10 @@ class GameMap:
                 for name, item in items.items():
                     if name == item_choice:
                         item_instance = copy.deepcopy(item)
+                        if item_instance.equippable: # Add modifiers to equipment
+                            item_instance.name = item_instance.equippable.generate_material(self.dungeon_level) + item_instance.name
+                            item_instance.name = item_instance.name + item_instance.equippable.generate_enchantment(self.dungeon_level)
+                            if ' of ' in item_instance.name: item_instance.color = item_instance.color * libtcod.grey # There should probably be a better way built into equippables to check if somthing is enchantment... like an enchantment attribute
                         item_instance.place(x, y)
                 entities.append(item_instance)
 

--- a/random_utils.py
+++ b/random_utils.py
@@ -1,6 +1,5 @@
 from random import randint
 
-
 # TODO: I don't love this because it still requires manual assignment for dungeon progression, but it works for now
 def from_dungeon_level(table, dungeon_level):
     """Returns the probablility of somthing spawning in a given dungeon level. 
@@ -12,7 +11,6 @@ def from_dungeon_level(table, dungeon_level):
             return value
 
     return 0
-
 
 def random_choice_index(chances):
     random_chance = randint(1, sum(chances))


### PR DESCRIPTION
Modifier class now exists. Two lists of different types of modifiers for equippables have also been added. Materials always come on an item and enchantments have a random chance to. Modifiers directly edit the bonuses and names of items in game_map for now but I'm considering adding a modifiers attribute to equippables in the future to hold onto that information. It should be noted that this feature completely breaks whatever balance there once was.