### PR TITLE
add speed attribute to player and other fighters

### DIFF
--- a/components/equipment.py
+++ b/components/equipment.py
@@ -42,6 +42,16 @@ class Equipment:
 
         return bonus
 
+    @property
+    def speed_bonus(self):
+        bonus = 0
+
+        for slot in vars(self).values():
+            if slot and slot.equippable:
+                bonus += slot.equippable.speed_bonus
+
+        return bonus
+
     def toggle_equip(self, equippable_entity):
         results = []
 

--- a/components/equippable.py
+++ b/components/equippable.py
@@ -3,10 +3,11 @@ from components.modifier import equippable_material, equippable_enchantment
 from equipment_slots import EquipmentSlotGroups
 
 class Equippable:
-    def __init__(self, slot, power_bonus=0, defense_bonus=0, max_hp_bonus=0):
+    def __init__(self, slot, power_bonus=0, defense_bonus=0, speed_bonus=0, max_hp_bonus=0):
         self.slot = slot
         self.power_bonus = power_bonus
         self.defense_bonus = defense_bonus
+        self.speed_bonus = speed_bonus
         self.max_hp_bonus = max_hp_bonus
         # Modifiers are currently added directly instead of being their own attributes but it might actually be nice to know what kind of modifier an item is
 

--- a/components/fighter.py
+++ b/components/fighter.py
@@ -9,6 +9,7 @@ class Fighter:
         self.base_defense = defense
         self.base_power = power
         self.base_speed = speed
+        self.current_moves = speed
         self.xp = xp
 
     # Equipment might want a rework so that it supports many mort effects easier.

--- a/components/fighter.py
+++ b/components/fighter.py
@@ -3,11 +3,12 @@ import tcod as libtcod
 from game_messages import Message
 
 class Fighter:
-    def __init__(self, hp, defense, power, xp=0):
+    def __init__(self, hp, defense, power, speed, xp=0):
         self.base_max_hp = hp
         self.hp = hp
         self.base_defense = defense
         self.base_power = power
+        self.base_speed = speed
         self.xp = xp
 
     # Equipment might want a rework so that it supports many mort effects easier.
@@ -39,6 +40,15 @@ class Fighter:
 
         return self.base_defense + bonus
 
+    @property
+    def speed(self):
+        if self.owner and self.owner.equipment:
+            bonus = self.owner.equipment.speed_bonus
+        else:
+            bonus = 0
+
+        return self.base_speed + bonus
+
     def take_damage(self, amount):
         results = []
 
@@ -69,3 +79,11 @@ class Fighter:
                 self.owner.name, target.name))})
 
         return results
+
+    # def damage_over_time(self, damage, turns):
+    #     for turn in turns:
+    #         self.take_damage(damage)
+
+    # def stun(self, turns):
+    #     for turn in turns:
+    #         skip turn

--- a/components/modifier.py
+++ b/components/modifier.py
@@ -17,5 +17,5 @@ equippable_enchantment = {
   '': Modifier([70], {}), # No Enchantment
   'Flames': Modifier([10], EquipmentSlotGroups.WEAPONS, {'power_bonus': 2}),
   'Strength': Modifier([10], {'power_bonus': 1, 'defense_bonus': 1}),
-  'Speed': Modifier([100], {'speed_bonus': 20})
+  'Speed': Modifier([100], {'speed_bonus': -20})
 }

--- a/components/modifier.py
+++ b/components/modifier.py
@@ -16,5 +16,6 @@ equippable_material = {
 equippable_enchantment = {
   '': Modifier([70], {}), # No Enchantment
   'Flames': Modifier([10], EquipmentSlotGroups.WEAPONS, {'power_bonus': 2}),
-  'Strength': Modifier([10], {'power_bonus': 1, 'defense_bonus': 1})
+  'Strength': Modifier([10], {'power_bonus': 1, 'defense_bonus': 1}),
+  'Speed': Modifier([100], {'speed_bonus': 20})
 }

--- a/engine.py
+++ b/engine.py
@@ -12,7 +12,6 @@ from game_messages import Message
 from render_functions import clear_all, render_all, popup
 from camera import Camera
 
-
 def play_game(player, entities, game_map, message_log, game_state, con, panel, constants, camera):
 
     fov_recompute = True
@@ -65,7 +64,6 @@ def play_game(player, entities, game_map, message_log, game_state, con, panel, c
 
         wheel_up = mouse_action.get('wheel_up')
         wheel_down = mouse_action.get('wheel_down')
-
 
         player_turn_results = []
 
@@ -144,6 +142,8 @@ def play_game(player, entities, game_map, message_log, game_state, con, panel, c
                 player.fighter.base_power += 1
             elif level_up == 'def':
                 player.fighter.base_defense += 1
+            elif level_up == 'speed':
+                player.fighter.base_speed += 10
 
             # game_state = previous_game_state   # This is the only way I found that the level up book doesn't lock
             game_state = GameStates.PLAYERS_TURN # the game, hopefully it's fine but it may give an extra turn on lvl up
@@ -281,7 +281,6 @@ def play_game(player, entities, game_map, message_log, game_state, con, panel, c
 
             else:
                 game_state = GameStates.PLAYERS_TURN
-
 
 def main():
     constants = get_constants()

--- a/input_handlers.py
+++ b/input_handlers.py
@@ -76,6 +76,8 @@ def handle_level_up_menu(key):
             return {'level_up': 'str'}
         elif key_char == 'c':
             return {'level_up': 'def'}
+        elif key_char == 'd':
+            return {'level_up': 'speed'}
 
     return {}
 

--- a/item_functions.py
+++ b/item_functions.py
@@ -189,7 +189,7 @@ def spawn_orc(*args, **kwargs):
     target_x = kwargs.get("target_x")
     target_y = kwargs.get("target_y")
 
-    fighter_component = Fighter(hp=20, defense=0, power=4, speed=50, xp=35)
+    fighter_component = Fighter(hp=20, defense=0, power=4, speed=150, xp=35)
     ai_component = BasicMonster()
     orc = Entity([], target_x, target_y, 'o', libtcod.desaturated_green, 'Orc', blocks=True,
                     render_order=RenderOrder.ACTOR, fighter=fighter_component, ai=ai_component)

--- a/item_functions.py
+++ b/item_functions.py
@@ -35,7 +35,6 @@ def heal(*args, **kwargs):
 
     return results
 
-
 def cast_lightning(*args, **kwargs):
     caster = args[0]
     entities = kwargs.get("entities")
@@ -190,7 +189,7 @@ def spawn_orc(*args, **kwargs):
     target_x = kwargs.get("target_x")
     target_y = kwargs.get("target_y")
 
-    fighter_component = Fighter(hp=20, defense=0, power=4, xp=35)
+    fighter_component = Fighter(hp=20, defense=0, power=4, speed=50, xp=35)
     ai_component = BasicMonster()
     orc = Entity([], target_x, target_y, 'o', libtcod.desaturated_green, 'Orc', blocks=True,
                     render_order=RenderOrder.ACTOR, fighter=fighter_component, ai=ai_component)

--- a/items.py
+++ b/items.py
@@ -28,6 +28,9 @@ items = {
   'cap':  Entity([[20, 1]], -1, -1, 'c', libtcod.darker_green, 'Cap',
     equippable=Equippable(EquipmentSlots.HEAD, defense_bonus=1)),
 
+  'boots': Entity([[20, 1]], -1, -1, 'b', libtcod.darker_green, 'Boots',
+    equippable=Equippable(EquipmentSlots.FEET, defense_bonus=1, speed_bonus=-10)),
+
   # USABLES
 
   'healing_potion': Entity([35], -1, -1, '!', libtcod.violet, 'Healing Potion', render_order=RenderOrder.ITEM, 

--- a/items.py
+++ b/items.py
@@ -29,7 +29,7 @@ items = {
     equippable=Equippable(EquipmentSlots.HEAD, defense_bonus=1)),
 
   'boots': Entity([[20, 1]], -1, -1, 'b', libtcod.darker_green, 'Boots',
-    equippable=Equippable(EquipmentSlots.FEET, defense_bonus=1, speed_bonus=-10)),
+    equippable=Equippable(EquipmentSlots.FEET, defense_bonus=1, speed_bonus=+10)),
 
   # USABLES
 

--- a/loader_functions/initialize_new_game.py
+++ b/loader_functions/initialize_new_game.py
@@ -88,7 +88,7 @@ def get_constants():
 
 
 def get_game_variables(constants):
-    fighter_component = Fighter(hp=100, defense=1, power=3)
+    fighter_component = Fighter(hp=100, defense=1, power=3, speed=50)
     inventory_component = Inventory(26)
     level_component = Level()
     equipment_component = Equipment()
@@ -142,7 +142,7 @@ def get_game_variables(constants):
 
 
 def get_arena_variables(constants):
-    fighter_component = Fighter(hp=100, defense=1, power=3)
+    fighter_component = Fighter(hp=100, defense=1, power=3, speed=50)
     inventory_component = Inventory(26)
     level_component = Level()
     equipment_component = Equipment()

--- a/loader_functions/initialize_new_game.py
+++ b/loader_functions/initialize_new_game.py
@@ -88,7 +88,7 @@ def get_constants():
 
 
 def get_game_variables(constants):
-    fighter_component = Fighter(hp=100, defense=1, power=3, speed=50)
+    fighter_component = Fighter(hp=100, defense=1, power=3, speed=100)
     inventory_component = Inventory(26)
     level_component = Level()
     equipment_component = Equipment()
@@ -142,7 +142,7 @@ def get_game_variables(constants):
 
 
 def get_arena_variables(constants):
-    fighter_component = Fighter(hp=100, defense=1, power=3, speed=50)
+    fighter_component = Fighter(hp=100, defense=1, power=3, speed=100)
     inventory_component = Inventory(26)
     level_component = Level()
     equipment_component = Equipment()

--- a/map_objects/game_map.py
+++ b/map_objects/game_map.py
@@ -16,7 +16,7 @@ from components.stairs import Stairs
 from random_utils import random_choice_from_dict, from_dungeon_level
 from monsters import monsters
 from items import items
-from random import randint
+from random import randint, seed
 
 
 class GameMap:
@@ -40,6 +40,8 @@ class GameMap:
 
         last_room_center_x = None
         last_room_center_y = None
+
+        # seed(0)
 
         # generate random size rooms
         for r in range(max_rooms):

--- a/menus.py
+++ b/menus.py
@@ -90,6 +90,7 @@ def level_up_menu(con, header, player, menu_width, screen_width, screen_height):
         "Constitution (+20 HP, from {0})".format(player.fighter.max_hp),
         "Strength (+1 attack, from {0})".format(player.fighter.power),
         "Agility (+1 defense, from {0})".format(player.fighter.defense),
+        "Speed (+10 speed, from {0})".format(player.fighter.speed)
     ]
 
     menu(con, header, options, menu_width, screen_width, screen_height)
@@ -171,6 +172,16 @@ def character_screen(
         libtcod.BKGND_NONE,
         libtcod.LEFT,
         "Defense: {0}".format(player.fighter.defense),
+    )
+    libtcod.console_print_rect_ex(
+        window,
+        0,
+        9,
+        char_screen_width,
+        char_screen_height,
+        libtcod.BKGND_NONE,
+        libtcod.LEFT,
+        "Speed: {0}".format(player.fighter.speed),
     )
 
     x = screen_width // 2 - char_screen_width // 2

--- a/menus.py
+++ b/menus.py
@@ -90,7 +90,7 @@ def level_up_menu(con, header, player, menu_width, screen_width, screen_height):
         "Constitution (+20 HP, from {0})".format(player.fighter.max_hp),
         "Strength (+1 attack, from {0})".format(player.fighter.power),
         "Agility (+1 defense, from {0})".format(player.fighter.defense),
-        "Speed (+10 speed, from {0})".format(player.fighter.speed)
+        "Speed (-10 speed, from {0})".format(player.fighter.speed)
     ]
 
     menu(con, header, options, menu_width, screen_width, screen_height)

--- a/monsters.py
+++ b/monsters.py
@@ -6,7 +6,7 @@ from components.fighter import Fighter
 from components.ai import BasicMonster
 
 monsters = {
-    'orc': Entity([80], -1, -1, 'o', libtcod.desaturated_green, 'Orc', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=20, defense=0, power=4, speed=20, xp=35), ai=BasicMonster()),
-    'troll': Entity([[15, 3], [30, 5], [60, 7]], -1, -1, 'T', libtcod.darker_green, 'Troll', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=30, defense=2, power=8, speed=20, xp=100), ai=BasicMonster()),
+    'orc': Entity([80], -1, -1, 'o', libtcod.desaturated_green, 'Orc', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=20, defense=0, power=4, speed=150, xp=35), ai=BasicMonster()),
+    'troll': Entity([[15, 3], [30, 5], [60, 7]], -1, -1, 'T', libtcod.darker_green, 'Troll', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=30, defense=2, power=8, speed=200, xp=100), ai=BasicMonster()),
 }
             

--- a/monsters.py
+++ b/monsters.py
@@ -6,7 +6,7 @@ from components.fighter import Fighter
 from components.ai import BasicMonster
 
 monsters = {
-    'orc': Entity([80], -1, -1, 'o', libtcod.desaturated_green, 'Orc', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=20, defense=0, power=4, xp=35), ai=BasicMonster()),
-    'troll': Entity([[15, 3], [30, 5], [60, 7]], -1, -1, 'T', libtcod.darker_green, 'Troll', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=30, defense=2, power=8, xp=100), ai=BasicMonster()),
+    'orc': Entity([80], -1, -1, 'o', libtcod.desaturated_green, 'Orc', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=20, defense=0, power=4, speed=20, xp=35), ai=BasicMonster()),
+    'troll': Entity([[15, 3], [30, 5], [60, 7]], -1, -1, 'T', libtcod.darker_green, 'Troll', blocks=True, render_order=RenderOrder.ACTOR, fighter=Fighter(hp=30, defense=2, power=8, speed=20, xp=100), ai=BasicMonster()),
 }
             


### PR DESCRIPTION
Added speed attribute to all fighters. Enemies will move more or less than the player depending on their difference in speed. Lower speed is better. Also added boots that affect speed. Player can also change speed when level up. Paid no mind to balance.